### PR TITLE
Add saving throws to spell cards.

### DIFF
--- a/Roll20Roller/Importer/Actions/SavingThrowsActions.cs
+++ b/Roll20Roller/Importer/Actions/SavingThrowsActions.cs
@@ -44,5 +44,15 @@ namespace Roll20Roller.Importer.Actions
             }
             return _statCheckPlusMinus(statName).Text.Equals("+") ? parsedBonus : -parsedBonus;
         }
+
+        public int GetProficiencyBonus()
+        {
+            var canParse = int.TryParse(_proficiencyBonus.Text, out var profBonus);
+            if (!canParse)
+            {
+                throw new Exception("Cannot parse proficiency bonus");
+            }
+            return _proficiencyPlusMinus.Text.Equals("+") ? profBonus : -profBonus;
+        }
     }
 }

--- a/Roll20Roller/Importer/Maps/SavingThrowsObjects.cs
+++ b/Roll20Roller/Importer/Maps/SavingThrowsObjects.cs
@@ -30,5 +30,9 @@ namespace Roll20Roller.Importer.Maps
         protected IWebElement _statCheckBonus(string statName) => _statCheckName(statName).FindElement(By.XPath("./parent::div/following-sibling::div[@class='ddbc-ability-summary__primary']/span/span[@class='ddbc-signed-number__number']"));
 
         #endregion
+
+        protected IWebElement _proficiencyBonusParent => _Driver.WaitForElement(By.CssSelector(".ct-proficiency-bonus-box__value > span:nth-child(1)"));
+        public IWebElement _proficiencyPlusMinus => _proficiencyBonusParent.FindElement(By.XPath("./span[1]"));
+        public IWebElement _proficiencyBonus => _proficiencyBonusParent.FindElement(By.XPath("./span[2]"));
     }
 }

--- a/Roll20Roller/Managers/RollGenerator.cs
+++ b/Roll20Roller/Managers/RollGenerator.cs
@@ -132,7 +132,7 @@ namespace Roll20Roller.Managers
             Clipboard.SetText(template);
         }
 
-        internal void GetSpellCard(Spell spell, bool gmOnly)
+        public void GetSpellCard(Spell spell, bool gmOnly)
         {
             var template = string.Empty;
 
@@ -147,8 +147,54 @@ namespace Roll20Roller.Managers
             + TemplateGenerateRow("Casting Time", spell.CastingTime)
             + TemplateGenerateRow("Range", spell.Range)
             + TemplateGenerateRow("Components", spell.Components)
-            + TemplateGenerateRow("Duration", spell.Duration)
-            + TemplateGenerateRow("Description", spell.Description);
+            + TemplateGenerateRow("Duration", spell.Duration);
+
+            if (spell.Description.Contains("saving throw"))
+            {                
+                var spellCastingAttribute = string.Empty;
+
+                switch (spell.Class)
+                {
+                    case CharacterClass.Bard:
+                        spellCastingAttribute = "CHA";
+                        break;
+                    case CharacterClass.Cleric:
+                        spellCastingAttribute = "WIS";
+                        break;
+                    case CharacterClass.Druid:
+                        spellCastingAttribute = "WIS";
+                        break;
+                    case CharacterClass.Paladin:
+                        spellCastingAttribute = "CHA";
+                        break;
+                    case CharacterClass.Ranger:
+                        spellCastingAttribute = "WIS";
+                        break;
+                    case CharacterClass.Sorcerer:
+                        spellCastingAttribute = "CHA";
+                        break;
+                    case CharacterClass.Warlock:
+                        spellCastingAttribute = "CHA";
+                        break;
+                    case CharacterClass.Wizard:
+                        spellCastingAttribute = "INT";
+                        break;
+                    default:
+                        spellCastingAttribute = string.Empty;
+                        break;
+                }
+                if (spellCastingAttribute.Equals(string.Empty))
+                {
+                    throw new Exception($"Spellcasting ability not found for class {spell.Class}");
+                }
+
+                var proficiencyBonus = _SavingThrows.GetProficiencyBonus();
+                var statBonus = _SavingThrows.GetStatCheckBonus(spellCastingAttribute);
+
+                template += TemplateGenerateRow("Saving Throw", $"{8+proficiencyBonus+statBonus} (Not including any magical enhancement)");
+            }
+
+            template += TemplateGenerateRow("Description", spell.Description);
 
             Clipboard.SetText(template);
         }


### PR DESCRIPTION
- Real saving throw unable to be obtained due to dndbeyond limitations with viewing the correct page in order to harvest the number.
- Added natural saving throws with no magical enhancement to rolls; added note to saving throw that no magical enhancements were added.