### PR TITLE
Allow specific chrome version to be used to prevent update breakage.

### DIFF
--- a/Roll20Roller/Roll20Roller.csproj
+++ b/Roll20Roller/Roll20Roller.csproj
@@ -69,7 +69,17 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
@@ -169,6 +179,9 @@
     <Content Include="SpellCsv\Spells_Wizard.csv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Importer\ChromeCompressed\ChromeZip.zip">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
@@ -202,6 +215,16 @@
     <Content Include="chromedriver.exe" />
   </ItemGroup>
   <ItemGroup>
+    <PublishFile Include="ChromeZip.zip">
+      <Visible>False</Visible>
+      <Group>
+      </Group>
+      <TargetPath>
+      </TargetPath>
+      <PublishState>DataFile</PublishState>
+      <IncludeHash>True</IncludeHash>
+      <FileType>File</FileType>
+    </PublishFile>
     <PublishFile Include="SpellCsv\Spells_Bard.csv">
       <Visible>False</Visible>
       <Group>

--- a/Roll20Roller/packages.config
+++ b/Roll20Roller/packages.config
@@ -3,4 +3,6 @@
   <package id="Microsoft.VisualStudio.SlowCheetah" version="3.2.26" targetFramework="net472" developmentDependency="true" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net472" />
   <package id="Selenium.WebDriver.ChromeDriver" version="85.0.4183.8700" targetFramework="net472" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
- Add packaged version of chrome to allow the packaged chromedriver to always use the correct version.

- This is now set to be "forever-available". no updating chrome/chromedriver is necessary; however, updating when possible is still prudent.