### PR TITLE
Add Spell Attack Damage Types

### DIFF
--- a/Roll20Roller/Importer/Actions/ActionsActions.cs
+++ b/Roll20Roller/Importer/Actions/ActionsActions.cs
@@ -63,7 +63,16 @@ namespace Roll20Roller.Importer.Actions
 
         public string GetDamageType(string attackName)
         {
-            return _attackDamageType(attackName).GetAttribute("data-original-title");
+            try
+            {
+                var damageType = _attackDamageType(attackName).GetAttribute("data-original-title");
+                return damageType;
+            }
+            catch (Exception)
+            {
+                var damageType = _spellAttackDamageType(attackName).GetAttribute("data-original-title");
+                return damageType;
+            }          
         }
 
         public string GetVersatileAttackRoll(string attackName)

--- a/Roll20Roller/Importer/Maps/ActionsObjects.cs
+++ b/Roll20Roller/Importer/Maps/ActionsObjects.cs
@@ -40,11 +40,7 @@ namespace Roll20Roller.Importer.Maps
         /// <returns></returns>
         protected IWebElement _attackDamageType(string attackName) => _attackParent(attackName).FindElement(By.XPath(".//span[@class='ddbc-tooltip  ddbc-damage']"));
 
-        // private IWebElement FindAttackParent(string attackName)
-        // {
-        //     var parentIndex = _allAttackNames.IndexOf(_attackName(attackName));
-        //     return _allAttackRows[parentIndex];
-        // }
+        protected IWebElement _spellAttackDamageType(string attackName) => _attackParent(attackName).FindElement(By.CssSelector(".ddbc-spell-damage-effect__damages > span:nth-child(2) > span:nth-child(1) > span:nth-child(1)"));
 
         #endregion
 


### PR DESCRIPTION
- Add ability to use spell attacks with alternate damage types when listed under the "Attacks" dropdown.

- Spell attack damage types are listed under a different web element class, and needed to have its own selector created