### PR TITLE
UX Updates for spells pulled from dndbeyond.

### DIFF
--- a/Roll20Roller/Forms/CharacterForm.Designer.cs
+++ b/Roll20Roller/Forms/CharacterForm.Designer.cs
@@ -101,6 +101,13 @@
             this.CbSpellHigherLevels = new System.Windows.Forms.CheckBox();
             this.BtnDdbSpell = new System.Windows.Forms.Button();
             this.DdlDdbSpells = new System.Windows.Forms.ComboBox();
+            this.StaticLblSpellModifier = new System.Windows.Forms.Label();
+            this.StaticLblSpellAttack = new System.Windows.Forms.Label();
+            this.StaticLblSpellSaveDc = new System.Windows.Forms.Label();
+            this.LblSpellModifier = new System.Windows.Forms.Label();
+            this.LblSpellAttack = new System.Windows.Forms.Label();
+            this.LblSpellSaveDc = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.GrpAttacks.SuspendLayout();
             this.GrpSavingThrows.SuspendLayout();
             this.GrpSkills.SuspendLayout();
@@ -108,6 +115,7 @@
             this.GrpClassOptions1.SuspendLayout();
             this.GrpCustom.SuspendLayout();
             this.GrpDdbSpells.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // LblCharacterName
@@ -345,7 +353,7 @@
             // CbGmOnly
             // 
             this.CbGmOnly.AutoSize = true;
-            this.CbGmOnly.Location = new System.Drawing.Point(304, 505);
+            this.CbGmOnly.Location = new System.Drawing.Point(304, 525);
             this.CbGmOnly.Name = "CbGmOnly";
             this.CbGmOnly.Size = new System.Drawing.Size(15, 14);
             this.CbGmOnly.TabIndex = 14;
@@ -356,7 +364,7 @@
             this.GrpClassOptions1.Controls.Add(this.CbRage);
             this.GrpClassOptions1.Location = new System.Drawing.Point(3, 232);
             this.GrpClassOptions1.Name = "GrpClassOptions1";
-            this.GrpClassOptions1.Size = new System.Drawing.Size(103, 79);
+            this.GrpClassOptions1.Size = new System.Drawing.Size(103, 108);
             this.GrpClassOptions1.TabIndex = 9;
             this.GrpClassOptions1.TabStop = false;
             this.GrpClassOptions1.Text = "Class Options";
@@ -374,7 +382,7 @@
             // LblGmOnly
             // 
             this.LblGmOnly.AutoSize = true;
-            this.LblGmOnly.Location = new System.Drawing.Point(218, 505);
+            this.LblGmOnly.Location = new System.Drawing.Point(218, 525);
             this.LblGmOnly.Name = "LblGmOnly";
             this.LblGmOnly.Size = new System.Drawing.Size(86, 13);
             this.LblGmOnly.TabIndex = 13;
@@ -420,7 +428,7 @@
             this.GrpCustom.Controls.Add(this.LblBonus);
             this.GrpCustom.Controls.Add(this.LblDice);
             this.GrpCustom.Controls.Add(this.LblDescription);
-            this.GrpCustom.Location = new System.Drawing.Point(3, 317);
+            this.GrpCustom.Location = new System.Drawing.Point(3, 346);
             this.GrpCustom.Name = "GrpCustom";
             this.GrpCustom.Size = new System.Drawing.Size(316, 164);
             this.GrpCustom.TabIndex = 11;
@@ -766,7 +774,7 @@
             // 
             // BtnDarkMode
             // 
-            this.BtnDarkMode.Location = new System.Drawing.Point(3, 495);
+            this.BtnDarkMode.Location = new System.Drawing.Point(3, 516);
             this.BtnDarkMode.Name = "BtnDarkMode";
             this.BtnDarkMode.Size = new System.Drawing.Size(75, 23);
             this.BtnDarkMode.TabIndex = 12;
@@ -776,15 +784,16 @@
             // 
             // GrpDdbSpells
             // 
+            this.GrpDdbSpells.Controls.Add(this.tableLayoutPanel1);
             this.GrpDdbSpells.Controls.Add(this.CbSpellHigherLevels);
             this.GrpDdbSpells.Controls.Add(this.BtnDdbSpell);
             this.GrpDdbSpells.Controls.Add(this.DdlDdbSpells);
             this.GrpDdbSpells.Location = new System.Drawing.Point(112, 233);
             this.GrpDdbSpells.Name = "GrpDdbSpells";
-            this.GrpDdbSpells.Size = new System.Drawing.Size(207, 78);
+            this.GrpDdbSpells.Size = new System.Drawing.Size(207, 107);
             this.GrpDdbSpells.TabIndex = 10;
             this.GrpDdbSpells.TabStop = false;
-            this.GrpDdbSpells.Text = "Spells Beta (From Ddb)";
+            this.GrpDdbSpells.Text = "Spells";
             // 
             // CbSpellHigherLevels
             // 
@@ -814,11 +823,91 @@
             this.DdlDdbSpells.Size = new System.Drawing.Size(193, 21);
             this.DdlDdbSpells.TabIndex = 0;
             // 
+            // StaticLblSpellModifier
+            // 
+            this.StaticLblSpellModifier.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.StaticLblSpellModifier.AutoSize = true;
+            this.StaticLblSpellModifier.Location = new System.Drawing.Point(3, 17);
+            this.StaticLblSpellModifier.Name = "StaticLblSpellModifier";
+            this.StaticLblSpellModifier.Size = new System.Drawing.Size(47, 13);
+            this.StaticLblSpellModifier.TabIndex = 3;
+            this.StaticLblSpellModifier.Text = "Damage";
+            // 
+            // StaticLblSpellAttack
+            // 
+            this.StaticLblSpellAttack.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.StaticLblSpellAttack.AutoSize = true;
+            this.StaticLblSpellAttack.Location = new System.Drawing.Point(64, 17);
+            this.StaticLblSpellAttack.Name = "StaticLblSpellAttack";
+            this.StaticLblSpellAttack.Size = new System.Drawing.Size(64, 13);
+            this.StaticLblSpellAttack.TabIndex = 4;
+            this.StaticLblSpellAttack.Text = "Spell Attack";
+            // 
+            // StaticLblSpellSaveDc
+            // 
+            this.StaticLblSpellSaveDc.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.StaticLblSpellSaveDc.AutoSize = true;
+            this.StaticLblSpellSaveDc.Location = new System.Drawing.Point(140, 17);
+            this.StaticLblSpellSaveDc.Name = "StaticLblSpellSaveDc";
+            this.StaticLblSpellSaveDc.Size = new System.Drawing.Size(50, 13);
+            this.StaticLblSpellSaveDc.TabIndex = 5;
+            this.StaticLblSpellSaveDc.Text = "Save DC";
+            // 
+            // LblSpellModifier
+            // 
+            this.LblSpellModifier.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.LblSpellModifier.AutoSize = true;
+            this.LblSpellModifier.Location = new System.Drawing.Point(11, 0);
+            this.LblSpellModifier.Name = "LblSpellModifier";
+            this.LblSpellModifier.Size = new System.Drawing.Size(35, 13);
+            this.LblSpellModifier.TabIndex = 6;
+            this.LblSpellModifier.Text = "Mod#";
+            // 
+            // LblSpellAttack
+            // 
+            this.LblSpellAttack.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.LblSpellAttack.AutoSize = true;
+            this.LblSpellAttack.Location = new System.Drawing.Point(73, 0);
+            this.LblSpellAttack.Name = "LblSpellAttack";
+            this.LblSpellAttack.Size = new System.Drawing.Size(45, 13);
+            this.LblSpellAttack.TabIndex = 7;
+            this.LblSpellAttack.Text = "Attack#";
+            // 
+            // LblSpellSaveDc
+            // 
+            this.LblSpellSaveDc.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.LblSpellSaveDc.AutoSize = true;
+            this.LblSpellSaveDc.Location = new System.Drawing.Point(144, 0);
+            this.LblSpellSaveDc.Name = "LblSpellSaveDc";
+            this.LblSpellSaveDc.Size = new System.Drawing.Size(39, 13);
+            this.LblSpellSaveDc.TabIndex = 8;
+            this.LblSpellSaveDc.Text = "Save#";
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 43.28358F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 56.71642F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 58F));
+            this.tableLayoutPanel1.Controls.Add(this.LblSpellSaveDc, 2, 0);
+            this.tableLayoutPanel1.Controls.Add(this.StaticLblSpellModifier, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.StaticLblSpellSaveDc, 2, 1);
+            this.tableLayoutPanel1.Controls.Add(this.LblSpellAttack, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.LblSpellModifier, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.StaticLblSpellAttack, 1, 1);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(8, 77);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(193, 30);
+            this.tableLayoutPanel1.TabIndex = 16;
+            // 
             // CharacterForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(322, 525);
+            this.ClientSize = new System.Drawing.Size(324, 542);
             this.Controls.Add(this.GrpDdbSpells);
             this.Controls.Add(this.BtnDarkMode);
             this.Controls.Add(this.RbDisadvantage);
@@ -851,6 +940,8 @@
             this.GrpCustom.PerformLayout();
             this.GrpDdbSpells.ResumeLayout(false);
             this.GrpDdbSpells.PerformLayout();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -930,5 +1021,12 @@
         private System.Windows.Forms.Button BtnDdbSpell;
         private System.Windows.Forms.ComboBox DdlDdbSpells;
         private System.Windows.Forms.CheckBox CbSpellHigherLevels;
+        private System.Windows.Forms.Label LblSpellSaveDc;
+        private System.Windows.Forms.Label LblSpellAttack;
+        private System.Windows.Forms.Label LblSpellModifier;
+        private System.Windows.Forms.Label StaticLblSpellSaveDc;
+        private System.Windows.Forms.Label StaticLblSpellAttack;
+        private System.Windows.Forms.Label StaticLblSpellModifier;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
     }
 }

--- a/Roll20Roller/Forms/CharacterForm.cs
+++ b/Roll20Roller/Forms/CharacterForm.cs
@@ -119,6 +119,9 @@ namespace Roll20Roller.Forms
             if (_SpellsDdb.HasAvailableSpells())
             {
                 _SpellsDdb.Init(DdlDdbSpells);
+                LblSpellModifier.Text = _SpellsDdb.SpellBonuses.modifier;
+                LblSpellAttack.Text = _SpellsDdb.SpellBonuses.spellAttack;
+                LblSpellSaveDc.Text = _SpellsDdb.SpellBonuses.saveDc;
             }
             else
             {
@@ -332,7 +335,7 @@ namespace Roll20Roller.Forms
         #region Spells from Ddb
 
         private void BtnDdbSpell_Click(object sender, EventArgs e)
-        {
+        {            
             _Roll.GetSpellCard(_SpellsDdb.GetSpellFromDdb(DdlDdbSpells.Text), GmOnly, CbSpellHigherLevels.Checked);
         }
 

--- a/Roll20Roller/Importer/Actions/SpellsFromDdbActions.cs
+++ b/Roll20Roller/Importer/Actions/SpellsFromDdbActions.cs
@@ -67,6 +67,11 @@ namespace Roll20Roller.Importer.Actions
             ddlDdbSpells.SelectedIndex = 1;
         }
 
+        public (string modifier, string spellAttack, string saveDc) SpellBonuses => 
+            (SpellModifierPlusMinus.Text + SpellModifier.Text,
+            SpellAttackPlusMinus.Text + SpellAttack.Text,
+            SaveDc.Text);
+
         public Spell GetSpellFromDdb(string spellName)
         {
             if (spellName.Equals(string.Empty) || spellName.Contains("==="))

--- a/Roll20Roller/Importer/Base/Wait.cs
+++ b/Roll20Roller/Importer/Base/Wait.cs
@@ -14,7 +14,7 @@ namespace Roll20Roller.Importer.Base
 {
     public static class Wait
     {
-        public static IWebElement WaitForElement(this IWebDriver driver, By by, int timeoutInMs = 30000) // 30 seconds
+        public static IWebElement WaitForElement(this IWebDriver driver, By by, int timeoutInMs = 45000) // 45 seconds
         {
             return new WebDriverWait(driver, TimeSpan.FromMilliseconds(timeoutInMs)).Until((drv) => {
                 try

--- a/Roll20Roller/Importer/Maps/SpellsObjects.cs
+++ b/Roll20Roller/Importer/Maps/SpellsObjects.cs
@@ -23,7 +23,12 @@ namespace Roll20Roller.Importer.Maps
             .FindElement(By.XPath("./parent::div/parent::div/parent::div"));
         protected List<IWebElement> SpellLevelGroups => _basicSpellsParent.FindElements(By.XPath("./div")).ToList();
         protected List<IWebElement> SpellNamesByLevel(int level) => SpellLevelGroups[level].FindElements(By.XPath("./div[2]/div[1]/div[2]/div//span[@class=\" ddbc-spell-name\"]")).ToList();
-
+        protected IWebElement _spellBonusParent => _Driver.WaitForElement(By.CssSelector(".ct-spells-level-casting__info"));
+        protected IWebElement SpellModifier => _spellBonusParent.FindElement(By.XPath("./div[1]/div[1]/span/span/span[2]"));
+        protected IWebElement SpellModifierPlusMinus => _spellBonusParent.FindElement(By.XPath("./div[1]/div[1]/span/span/span[1]"));
+        protected IWebElement SpellAttack => _spellBonusParent.FindElement(By.XPath("./div[2]/div[1]/span/span/span[2]"));
+        protected IWebElement SpellAttackPlusMinus => _spellBonusParent.FindElement(By.XPath("./div[2]/div[1]/span/span/span[1]"));
+        protected IWebElement SaveDc => _spellBonusParent.FindElement(By.XPath("./div[3]/div[1]/span"));
 
         // detailed content - side pane
         private IWebElement _detailedSpellsParent => _Driver.WaitForElement(By.CssSelector(".ct-spell-detail"));

--- a/Roll20Roller/Managers/RollGenerator.cs
+++ b/Roll20Roller/Managers/RollGenerator.cs
@@ -20,12 +20,14 @@ namespace Roll20Roller.Managers
             _MainPage = new MainPageActions(charId);
             _Actions = new ActionsActions(charId);
             _SavingThrows = new SavingThrowsActions(charId);
+            _Spells = new SpellsFromDdbActions(charId);
         }
 
         public SkillsActions _Skills;
         public MainPageActions _MainPage;
         public ActionsActions _Actions;
         public SavingThrowsActions _SavingThrows;
+        public SpellsFromDdbActions _Spells;
 
         private string _gmWhisper = "/w gm ";
 
@@ -134,10 +136,12 @@ namespace Roll20Roller.Managers
 
         public void GetSpellCard(Spell spell, bool gmOnly, bool displayHigherLevelsText)
         {
+            Clipboard.Clear();
             if (!spell.Description.Equals("Invalid"))
             {
                 var componentTypes = new StringBuilder();
                 spell.ComponentTypes.ForEach(t => componentTypes.Append($"{t} "));
+                var range = int.TryParse(spell.Range, out _) ? $"{spell.Range} ft." : spell.Range;
 
                 var template = string.Empty;
 
@@ -146,13 +150,17 @@ namespace Roll20Roller.Managers
                     template += _gmWhisper;
                 }
 
-                template += TemplateStartDefaultTemplate($"{spell.Name} - {spell.School} ({spell.Class})")
-                + TemplateGenerateRow("Level", spell.Level.ToString())
-                + TemplateGenerateRow("Casting Time", spell.CastingTime)
-                + TemplateGenerateRow("Range/Area", spell.Range)
-                + TemplateGenerateRow("Components", componentTypes.ToString().Trim())
-                + TemplateGenerateRow("Materials", spell.ComponentMaterials)
+                template += TemplateStartDefaultTemplate(
+                    $"{spell.Name}\n" +
+                    $"Level {spell.Level.ToString()} {spell.School}\n" +
+                    $"{spell.Class}")
+                + TemplateGenerateRow("Casting", spell.CastingTime)
+                + TemplateGenerateRow("Range", range)
+                + TemplateGenerateRow("Components", $"{componentTypes.ToString().Trim()}; {spell.ComponentMaterials}")
                 + TemplateGenerateRow("Duration", spell.Duration)
+                + TemplateGenerateRow("Bonuses", $"Modifier: {_Spells.SpellBonuses.modifier}\n" +
+                                                 $"Spell Attack: {_Spells.SpellBonuses.spellAttack}\n" +
+                                                 $"Save DC: {_Spells.SpellBonuses.saveDc}")                
                 + TemplateGenerateRow("Short Description", spell.Description);
 
                 if (displayHigherLevelsText)


### PR DESCRIPTION
- reconfigured how details appear in spell card.
- added damage bonus, spell attack bonus, and save dc to the main panel of R2R for visibility and user reference.
- Added damage/attack/save statistics to spell cards so it is easier for the DM to assist newer players.
- Removed (beta) tag from the spells UI group box - this seems ready for release; however i am still open for future feedback.